### PR TITLE
Update colorblinding.js - fix

### DIFF
--- a/colorblinding.js
+++ b/colorblinding.js
@@ -38,7 +38,7 @@ function changeColors(type) {
 }
 
 function revertColors(document) {
-    var css = 'html { -webkit-filter: none; -moz-filter: none; -o-filter: none; -ms-filter: none; }';
+    var css = 'html { -webkit-filter: none; -moz-filter: none; -o-filter: none; -ms-filter: none; } #blockColorblindContent { display: none; }';
     applyingStyle(document, css);
 }
 


### PR DESCRIPTION
Fix for #blockColorblindContent { display: none; }

With Bootstrap 4, above the footer we got extra white space. I fixed this setting #blockColorblindContent with display none. Setting #blockColorblindContent to display none is much better compatible wise, it's still working as we would expect.

![rx5B8KTBrf](https://user-images.githubusercontent.com/980950/62114756-97613400-b2b7-11e9-89cd-5663db41e007.png)

After setting #blockColorblindContent { display: none; }
![chrome_WET9Af1hLY](https://user-images.githubusercontent.com/980950/62115235-60d7e900-b2b8-11e9-8472-bc02512b4b10.png)

Fixes #5 and #6 